### PR TITLE
Java 11 compatibility

### DIFF
--- a/core/src/main/java/com/kumuluz/ee/graphql/processor/AnnotationProcessor.java
+++ b/core/src/main/java/com/kumuluz/ee/graphql/processor/AnnotationProcessor.java
@@ -132,7 +132,7 @@ public class AnnotationProcessor extends AbstractProcessor{
             reader = resource.openReader(true);
             readOldServiceFile(serviceClassNames, reader);
             return resource;
-        } catch (FileNotFoundException e) {
+        } catch (Exception e) {
             // close reader, return null
         } finally {
             if (reader != null) {

--- a/pom.xml
+++ b/pom.xml
@@ -30,11 +30,12 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <kumuluzee.version>2.5.2</kumuluzee.version>
-        <graphql-java.version>8.0</graphql-java.version>
-        <gson.version>2.8.2</gson.version>
-        <spqr.version>0.9.7</spqr.version>
-        <kumuluzee-rest.version>1.2.1</kumuluzee-rest.version>
+        <kumuluzee.version>3.0.0</kumuluzee.version>
+        <graphql-java.version>9.2</graphql-java.version>
+        <gson.version>2.8.5</gson.version>
+        <spqr.version>0.9.8</spqr.version>
+        <kumuluzee-rest.version>1.2.2</kumuluzee-rest.version>
+        <jaxb-api.version>2.3.0</jaxb-api.version>
     </properties>
 
     <scm>
@@ -102,12 +103,28 @@
         </dependencies>
     </dependencyManagement>
 
+    <profiles>
+        <profile>
+            <id>java9-modules</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                    <version>${jaxb-api.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.8.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>


### PR DESCRIPTION
This commit enables Java 11 compatibility with the extension. It adds jaxb-api as a dependency and increases versions of dependencies.