### PR TITLE
Fixed a bug with multiple GraphQLApplication classes and upped versions

### DIFF
--- a/core/src/main/java/com/kumuluz/ee/graphql/GraphQLExtension.java
+++ b/core/src/main/java/com/kumuluz/ee/graphql/GraphQLExtension.java
@@ -26,12 +26,16 @@ import com.kumuluz.ee.common.config.EeConfig;
 import com.kumuluz.ee.common.dependencies.EeComponentDependency;
 import com.kumuluz.ee.common.dependencies.EeComponentType;
 import com.kumuluz.ee.common.dependencies.EeExtensionDef;
+import com.kumuluz.ee.common.exceptions.KumuluzServerException;
 import com.kumuluz.ee.common.wrapper.KumuluzServerWrapper;
 import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
 import com.kumuluz.ee.graphql.servlets.GraphQLServlet;
 import com.kumuluz.ee.jetty.JettyServletServer;
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceLoader;
 import java.util.logging.Logger;
 
 /**
@@ -47,7 +51,20 @@ public class GraphQLExtension implements Extension {
     private static final Logger LOG = Logger.getLogger(GraphQLExtension.class.getName());
 
     @Override
+    public boolean isEnabled() {
+        return ConfigurationUtil
+                .getInstance()
+                .getBoolean("kumuluzee.graphql.enabled")
+                .orElse(true);
+    }
+
+    @Override
     public void load() {
+        List<GraphQLApplication> applications = new ArrayList<>();
+        ServiceLoader.load(GraphQLApplication.class).forEach(applications::add);
+        if(applications.size() > 1) {
+            throw new KumuluzServerException("Found multiple declarations of GraphQLApplication. Please only provide one.");
+        }
     }
 
     @Override

--- a/core/src/main/java/com/kumuluz/ee/graphql/servlets/GraphQLServlet.java
+++ b/core/src/main/java/com/kumuluz/ee/graphql/servlets/GraphQLServlet.java
@@ -67,16 +67,15 @@ public class GraphQLServlet extends HttpServlet {
 
     @Override
     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-        QueryParameters parameters = QueryParameters.from(req);
-        if (parameters.getQuery() == null) {
-            resp.setStatus(400);
-            return;
-        }
-        processQuery(parameters, resp);
+        processRequest(req, resp);
     }
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        processRequest(req, resp);
+    }
+
+    private void processRequest(HttpServletRequest req, HttpServletResponse resp) throws IOException {
         QueryParameters parameters = QueryParameters.from(req);
         if (parameters.getQuery() == null) {
             resp.setStatus(400);
@@ -89,11 +88,9 @@ public class GraphQLServlet extends HttpServlet {
         if(schema == null) {
             List<GraphQLApplication> applications = new ArrayList<>();
             ServiceLoader.load(GraphQLApplication.class).forEach(applications::add);
-            Class applicationClass = null;
+            Class applicationClass;
             if(applications.size() == 1) {
-               applicationClass = applications.get(0).getClass();
-            } else if(applications.size() > 1) {
-                LOG.warning("Found multiple declaratinos of GraphQLApplication. Please only provide one.");
+                applicationClass = applications.get(0).getClass();
             } else {
                 applicationClass = GraphQLApplication.class;
             }
@@ -196,7 +193,7 @@ public class GraphQLServlet extends HttpServlet {
         JsonKit.toJson(response, executionResult.toSpecification());
     }
 
-    public List<Class<?>> getResourceClasses() {
+    private List<Class<?>> getResourceClasses() {
         List<Class<?>> resourceClasses = new ArrayList<>();
 
         ClassLoader classLoader = getClass().getClassLoader();

--- a/pom.xml
+++ b/pom.xml
@@ -30,10 +30,10 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <kumuluzee.version>3.0.0</kumuluzee.version>
-        <graphql-java.version>9.2</graphql-java.version>
+        <kumuluzee.version>3.2.0</kumuluzee.version>
+        <graphql-java.version>11.0</graphql-java.version>
         <gson.version>2.8.5</gson.version>
-        <spqr.version>0.9.8</spqr.version>
+        <spqr.version>0.9.9</spqr.version>
         <kumuluzee-rest.version>1.2.3</kumuluzee-rest.version>
         <jaxb-api.version>2.3.0</jaxb-api.version>
 


### PR DESCRIPTION
Changes in this pull request:
- Declaring multiple GraphQLApplication classes is now disallowed and throws exception at startup.
- Upped versions of GraphQL, GraphQL SPQR and KumuluzEE.
- Added an option to disable extension.
- Smaller code improvements.
