### PR TITLE
Fixed pagination limit bug

### DIFF
--- a/core/src/main/java/com/kumuluz/ee/graphql/utils/GraphQLUtils.java
+++ b/core/src/main/java/com/kumuluz/ee/graphql/utils/GraphQLUtils.java
@@ -88,9 +88,9 @@ public class GraphQLUtils<T> {
         if(offset > count) {
             return new PaginationWrapper<T>(output, new ArrayList<>());
         } else if(offset + limit > count) {
-            limit = count;
+            return new PaginationWrapper<T>(output, list.subList(offset, count));
         }
-        return new PaginationWrapper<T>(output, list.subList(offset, limit));
+        return new PaginationWrapper<T>(output, list.subList(offset, offset + limit));
     }
 
     public static <T> List<T> processWithoutPagination(List<T> l, Sort s, Filter f) {


### PR DESCRIPTION
The `limit` parameter of `PaginationWrapper` is not working correctly.

For example, `offset = 5, limit = 6, count = 11` returns 1 element.
However,      `offset = 5, limit = 7, count = 11` returns 6 elements.

My changes should fix this issue.